### PR TITLE
github-actions: add codecov upload

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -31,7 +31,8 @@ jobs:
     - name: Test with tox
       run: |
         pyenv="py$(echo "${{ matrix.python-version }}" | tr -d '.')"
-        tox -e ${pyenv}-test,${pyenv}-rapidjson,flake8,lint
+        tox -e ${pyenv}-test,flake8,lint
+        tox -e ${pyenv}-rapidjson -- --cov-append
     - name: Check code format with black
       if: matrix.python-version == 3.9
       run: tox -e black

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -38,6 +38,11 @@ jobs:
     - name: Check package
       if: matrix.python-version == 3.9
       run: tox -e check_package
+    - name: Upload to coverage
+      uses: codecov/codecov-action@v1.2.1
+      with:
+        files: coverage.xml
+        flags: ${{ matrix.python-version }},${{ matrix.tox-testenv }}
     - name: Publish package to PyPI
       uses: pypa/gh-action-pypi-publish@master
       if: >-

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -40,9 +40,6 @@ jobs:
       run: tox -e check_package
     - name: Upload to coverage
       uses: codecov/codecov-action@v1.2.1
-      with:
-        files: coverage.xml
-        flags: ${{ matrix.python-version }},${{ matrix.tox-testenv }}
     - name: Publish package to PyPI
       uses: pypa/gh-action-pypi-publish@master
       if: >-

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [tool:pytest]
 addopts = -v --junit-xml=test-report.xml
           --doctest-modules
-          --cov=riotctrl --cov-branch --cov-append
+          --cov=riotctrl --cov-branch
           --cov-report=term-missing --cov-report=xml
 testpaths = riotctrl
 markers =

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [tool:pytest]
 addopts = -v --junit-xml=test-report.xml
           --doctest-modules
-          --cov=riotctrl --cov-branch
+          --cov=riotctrl --cov-branch --cov-append
           --cov-report=term-missing --cov-report=xml
 testpaths = riotctrl
 markers =

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 addopts = -v --junit-xml=test-report.xml
           --doctest-modules
           --cov=riotctrl --cov-branch
-          --cov-report=term --cov-report=xml --cov-report=html
+          --cov-report=term-missing --cov-report=xml
 testpaths = riotctrl
 markers =
     rapidjson

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,11 +7,6 @@ testpaths = riotctrl
 markers =
     rapidjson
 
-[coverage:report]
-exclude_lines = pragma: no cover
-                raise NotImplementedError
-                return NotImplemented
-
 [pylint]
 reports = no
 max-line-length = 88

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,6 +7,11 @@ testpaths = riotctrl
 markers =
     rapidjson
 
+[coverage:report]
+exclude_lines = pragma: no cover
+                raise NotImplementedError
+                return NotImplemented
+
 [pylint]
 reports = no
 max-line-length = 88


### PR DESCRIPTION
This adds an upload of the coverage report to codecov. This way, we can track if a PR increases or decreases test coverage.

Requires #2 to be mergable into protected branch :sweat_smile: 