### PR TITLE
gh-actions: publish to pypi on tag creation

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -30,3 +30,12 @@ jobs:
         pip install tox tox-gh-actions
     - name: Test with tox
       run: tox
+    - name: Publish package to PyPI
+      uses: pypa/gh-action-pypi-publish@master
+      if: >-
+        matrix.python-version == 3.8 &&
+        github.event_name == 'push' &&
+        startsWith(github.event.ref, 'refs/tags')
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
Borrowed from [riotgen](https://github.com/aabadie/riot-generator/blob/master/.github/workflows/continuous-integration.yml#L67-L76) ;-)