### PR TITLE
gh-actions: fix dist target dir

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -39,3 +39,4 @@ jobs:
       with:
         user: __token__
         password: ${{ secrets.PYPI_TOKEN }}
+        packages_dir: .tox/dist/


### PR DESCRIPTION
See https://github.com/pypa/gh-action-pypi-publish#customizing-target-package-dists-directory.

This worked also for the first publish of https://pypi.org/project/riotctrl/