### PR TITLE
riotctrl.shell: restore terminal after reset

### DIFF
--- a/riotctrl/__init__.py
+++ b/riotctrl/__init__.py
@@ -8,4 +8,4 @@ It could provide an RPC interface to a node in Python over the serial port
 and maybe also over network.
 """
 
-__version__ = '0.1.0'
+__version__ = '0.1.1'

--- a/riotctrl/shell.py
+++ b/riotctrl/shell.py
@@ -39,7 +39,7 @@ class ShellInteraction():
             self.stop_term()
 
     def _start_replwrap(self):
-        if self.replwrap is None:
+        if self.replwrap is None or self.replwrap.child != self.riotctrl.term:
             # consume potentially shown prompt to be on the same ground as if
             # it is not shown
             self.riotctrl.term.expect_exact(["> ", pexpect.TIMEOUT],

--- a/riotctrl/tests/shell_test.py
+++ b/riotctrl/tests/shell_test.py
@@ -57,6 +57,19 @@ def test_shell_interaction_cmd_first_prompt_missing(app_pidfile_env):
         assert 'snafoo' in res
 
 
+def test_shell_interaction_cmd_reset_term(app_pidfile_env):
+    """Test basic functionalities with the 'shell' application."""
+    ctrl = init_ctrl(app_pidfile_env)
+    ctrl.start_term()
+    shell = riotctrl.shell.ShellInteraction(ctrl)
+    res = shell.cmd('foobar')
+    assert 'foobar' in res
+    ctrl.start_term()   # reset's term implicitly
+    res = shell.cmd('snafoo')
+    assert 'snafoo' in res
+    ctrl.stop_term()
+
+
 class Snafoo(riotctrl.shell.ShellInteraction):
     """Test inheritance class to test check_term decorator"""
     @riotctrl.shell.ShellInteraction.check_term


### PR DESCRIPTION
When resetting the terminal mid-test (which might be necessary e.g. if the connection is lost or other use-cases), the `replwrap` does not notice that. This ensures that it is.

I provided a test case that shows this error. With the second commit it should succeed in the CI.