### PR TITLE
gh-actions: do not use tox-gh-actions plugin

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       max-parallel: 5
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8]
+        python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v1
@@ -35,7 +35,7 @@ jobs:
     - name: Publish package to PyPI
       uses: pypa/gh-action-pypi-publish@master
       if: >-
-        matrix.python-version == 3.8 &&
+        matrix.python-version == 3.9 &&
         github.event_name == 'push' &&
         startsWith(github.event.ref, 'refs/tags')
       with:

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -14,7 +14,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
-      max-parallel: 4
+      max-parallel: 5
       matrix:
         python-version: [3.5, 3.6, 3.7, 3.8]
 
@@ -27,9 +27,11 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install tox tox-gh-actions
+        python -m pip install tox
     - name: Test with tox
-      run: tox
+      run: |
+        pyenv="py$(echo "${{ matrix.python-version }}" | tr -d '.')"
+        tox -e ${pyenv},test,flake8,lint
     - name: Publish package to PyPI
       uses: pypa/gh-action-pypi-publish@master
       if: >-

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,8 @@ python =
     3.5: py35,test
     3.6: py36,test
     3.7: py37,test
-    3.8: py38,test,lint,flake8
+    3.8: py38,test
+    3.9: py39,test,lint,flake8
 
 [testenv]
 basepython = python3


### PR DESCRIPTION
Same as with https://github.com/RIOT-OS/Release-Specs/pull/200. The `tox-gh-actions` plugin is broken, so let's not use it.