### PR TITLE
riotctrl: drop python 3.5 testing

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       max-parallel: 5
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9]
         tox-testenv: ["test", "test-rapidjson"]
 
     steps:

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,6 @@ setup(
     classifiers=['Development Status :: 2 - Pre-Alpha',
                  'Programming Language :: Python',
                  'Programming Language :: Python :: 3',
-                 'Programming Language :: Python :: 3.5',
                  'Programming Language :: Python :: 3.6',
                  'Programming Language :: Python :: 3.7',
                  'Programming Language :: Python :: 3.8',
@@ -51,5 +50,5 @@ setup(
     extra_require={
         'rapidjson': ['python-rapidjson']
     },
-    python_requires='>=3.5',
+    python_requires='>=3.6',
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,8 @@
 [tox]
-envlist = test,lint,flake8,py35,py36,py37,py38
+envlist = test,lint,flake8,py36,py37,py38,py39
 
 [gh-actions]
 python =
-    3.5: py35,test
     3.6: py36,test
     3.7: py37,test
     3.8: py38,test


### PR DESCRIPTION
Python 3.5 reached EOL with the release of [Python 3.5.10], so we should drop support for it for the next release of `riotctrl` as well.

[Python 3.5.10]: https://www.python.org/downloads/release/python-3510/