### PR TITLE
gh-actions: fix publishing

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -37,6 +37,7 @@ jobs:
       uses: pypa/gh-action-pypi-publish@master
       if: >-
         matrix.python-version == 3.9 &&
+        matrix.tox-testenv == 'test' &&
         github.event_name == 'push' &&
         startsWith(github.event.ref, 'refs/tags')
       with:


### PR DESCRIPTION
The new build matrix element introduced in #8 causes the Github Action to try to publish the package twice. This makes the second run [fail with a 400 Bad Request in the publish step](https://github.com/RIOT-OS/riotctrl/runs/1748060329?check_suite_focus=true#step:7:22). This restricts the publishing just to the `test` build martrix element