### PR TITLE
tests: remove accidentally pushed scope reduction

### DIFF
--- a/riotctrl/__init__.py
+++ b/riotctrl/__init__.py
@@ -8,4 +8,4 @@ It could provide an RPC interface to a node in Python over the serial port
 and maybe also over network.
 """
 
-__version__ = '0.2.0'
+__version__ = '0.2.1'

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,6 @@ addopts = -v --junit-xml=test-report.xml
           --doctest-modules
           --cov=riotctrl --cov-branch
           --cov-report=term --cov-report=xml --cov-report=html
-          -k shell_json_test
 testpaths = riotctrl
 markers =
     rapidjson


### PR DESCRIPTION
I accidentally pushed a scope reduction of the tests (to locally speed up testing) that never were supposed to be pushed and slipped through the review. This removes that and bumps the version for this bug fix.