### PR TITLE
Fix and correctly test rapidjson dependency

### DIFF
--- a/riotctrl/__init__.py
+++ b/riotctrl/__init__.py
@@ -8,4 +8,4 @@ It could provide an RPC interface to a node in Python over the serial port
 and maybe also over network.
 """
 
-__version__ = '0.2.1'
+__version__ = '0.2.2'

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
                  'Environment :: Console',
                  'Topic :: Utilities', ],
     install_requires=['pexpect', 'psutil'],
-    extra_require={
+    extras_require={
         'rapidjson': ['python-rapidjson']
     },
     python_requires='>=3.6',

--- a/tox.ini
+++ b/tox.ini
@@ -30,7 +30,7 @@ commands =
 deps =
     pytest
     pytest-cov
-    python-rapidjson
+    .[rapidjson]
 commands =
     pytest -m "rapidjson"
 


### PR DESCRIPTION
When I tried to use our shiny new RapidJSON class, I was surprised that `pip install riotctrl[rapidjson]` doesn't install rapidjson :(. This fixes that.