### PR TITLE
pexpect: set minimum version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
                  'Intended Audience :: End Users/Desktop',
                  'Environment :: Console',
                  'Topic :: Utilities', ],
-    install_requires=['pexpect', 'psutil'],
+    install_requires=['pexpect>=4.7', 'psutil'],
     extras_require={
         'rapidjson': ['python-rapidjson']
     },


### PR DESCRIPTION
We are using `replwrap` with `async_` which was [introduced in pexpect 4.7][1]. Fixes #7.

[1]: https://github.com/pexpect/pexpect/commit/e4732bd0f76936ac26884dada3f83046b2d6e72a