### PR TITLE
riotctrl.ctrl: make `start_term` targets configurable and default it to `make cleanterm`

### DIFF
--- a/riotctrl/__init__.py
+++ b/riotctrl/__init__.py
@@ -8,4 +8,4 @@ It could provide an RPC interface to a node in Python over the serial port
 and maybe also over network.
 """
 
-__version__ = '0.2.2'
+__version__ = '0.3.0'

--- a/riotctrl/ctrl.py
+++ b/riotctrl/ctrl.py
@@ -88,6 +88,7 @@ class RIOTCtrl():
 
     MAKE_ARGS = ()
     RESET_TARGETS = ('reset',)
+    TERM_TARGETS = ('term',)
 
     def __init__(self, application_directory='.', env=None):
         self._application_directory = application_directory
@@ -133,7 +134,7 @@ class RIOTCtrl():
         """
         self.stop_term()
 
-        term_cmd = self.make_command(['term'])
+        term_cmd = self.make_command(self.TERM_TARGETS)
         self.term = self.TERM_SPAWN_CLASS(term_cmd[0], args=term_cmd[1:],
                                           env=self.env, **spawnkwargs)
 

--- a/riotctrl/ctrl.py
+++ b/riotctrl/ctrl.py
@@ -88,7 +88,7 @@ class RIOTCtrl():
 
     MAKE_ARGS = ()
     RESET_TARGETS = ('reset',)
-    TERM_TARGETS = ('term',)
+    TERM_TARGETS = ('cleanterm',)
 
     def __init__(self, application_directory='.', env=None):
         self._application_directory = application_directory

--- a/riotctrl/tests/utils/application/Makefile
+++ b/riotctrl/tests/utils/application/Makefile
@@ -18,5 +18,7 @@ flash:
 reset:
 	kill -USR1 $(CTRLPID) 2>/dev/null || true
 
+cleanterm: term
+
 term:
 	$(Q)sh -c 'echo $$$$ > $(PIDFILE); exec $(CTRL_WRAPPER) $(APPLICATION)'


### PR DESCRIPTION
Most test environments require `make cleanterm` to be used. This allows for that to be configurable (and defaults to that option).