### PR TITLE
Revert "riotctrl: drop python 3.5 testing" 

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       max-parallel: 5
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
         tox-testenv: ["test", "test-rapidjson"]
 
     steps:

--- a/riotctrl/__init__.py
+++ b/riotctrl/__init__.py
@@ -8,4 +8,4 @@ It could provide an RPC interface to a node in Python over the serial port
 and maybe also over network.
 """
 
-__version__ = '0.3.0'
+__version__ = '0.3.1'

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ setup(
     classifiers=['Development Status :: 2 - Pre-Alpha',
                  'Programming Language :: Python',
                  'Programming Language :: Python :: 3',
+                 'Programming Language :: Python :: 3.5',
                  'Programming Language :: Python :: 3.6',
                  'Programming Language :: Python :: 3.7',
                  'Programming Language :: Python :: 3.8',
@@ -50,5 +51,5 @@ setup(
     extras_require={
         'rapidjson': ['python-rapidjson']
     },
-    python_requires='>=3.6',
+    python_requires='>=3.5',
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,9 @@
 [tox]
-envlist = test,lint,flake8,py36,py37,py38,py39
+envlist = test,lint,flake8,py35,py36,py37,py38,py39
 
 [gh-actions]
 python =
+    3.5: py35,test
     3.6: py36,test
     3.7: py37,test
     3.8: py38,test


### PR DESCRIPTION
This reverts #10.

Sadly, some of our test environment still runs on Python 3.5, so we need to revert this for now.