### PR TITLE
riotctrl.shell: add capabilities for configuration

### DIFF
--- a/riotctrl/shell/__init__.py
+++ b/riotctrl/shell/__init__.py
@@ -28,9 +28,11 @@ class ShellInteraction():
     Base class for shell interactions
 
     :param riotctrl: a RIOTCtrl object
+    :param prompt: the prompt of the shell (default: '> ')
     """
-    def __init__(self, riotctrl):
+    def __init__(self, riotctrl, prompt='> '):
         self.riotctrl = riotctrl
+        self.prompt = prompt
         self.replwrap = None
         self.term_was_started = False
 
@@ -42,13 +44,13 @@ class ShellInteraction():
         if self.replwrap is None or self.replwrap.child != self.riotctrl.term:
             # consume potentially shown prompt to be on the same ground as if
             # it is not shown
-            self.riotctrl.term.expect_exact(["> ", pexpect.TIMEOUT],
+            self.riotctrl.term.expect_exact([self.prompt, pexpect.TIMEOUT],
                                             timeout=.1)
             # enforce prompt to be shown by sending newline
             self.riotctrl.term.sendline("")
             self.replwrap = pexpect.replwrap.REPLWrapper(
                 self.riotctrl.term,
-                orig_prompt="> ",
+                orig_prompt=self.prompt,
                 prompt_change=None,
             )
 

--- a/riotctrl/shell/__init__.py
+++ b/riotctrl/shell/__init__.py
@@ -30,6 +30,8 @@ class ShellInteraction():
     :param riotctrl: a RIOTCtrl object
     :param prompt: the prompt of the shell (default: '> ')
     """
+    PROMPT_TIMEOUT = .5
+
     def __init__(self, riotctrl, prompt='> '):
         self.riotctrl = riotctrl
         self.prompt = prompt
@@ -45,7 +47,7 @@ class ShellInteraction():
             # consume potentially shown prompt to be on the same ground as if
             # it is not shown
             self.riotctrl.term.expect_exact([self.prompt, pexpect.TIMEOUT],
-                                            timeout=.1)
+                                            timeout=self.PROMPT_TIMEOUT)
             # enforce prompt to be shown by sending newline
             self.riotctrl.term.sendline("")
             self.replwrap = pexpect.replwrap.REPLWrapper(

--- a/riotctrl/tests/utils/application/shell.py
+++ b/riotctrl/tests/utils/application/shell.py
@@ -7,9 +7,10 @@ import sys
 
 PARSER = argparse.ArgumentParser()
 PARSER.add_argument('skip_first_prompt', type=bool, default=False, nargs='?')
+PARSER.add_argument('--prompt', type=str, default="> ")
 
 
-def main(skip_first_prompt=False):
+def main(skip_first_prompt=False, prompt="> "):
     """Print some header and echo the output."""
     if not skip_first_prompt:
         print('Starting RIOT Ctrl')
@@ -18,7 +19,7 @@ def main(skip_first_prompt=False):
         print(input())
         print()
     while True:
-        print(input("> "))
+        print(input(prompt))
         print()
 
 


### PR DESCRIPTION
This

- adds an initialization parameter to change the prompt
- makes the timeout to wait for the initial prompt configurable

This should fix the issues with the ESP32s in the CI, I faced in https://github.com/RIOT-OS/RIOT/pull/15951