### PR TITLE
riotctrl: bump version to v0.4.0

### DIFF
--- a/riotctrl/__init__.py
+++ b/riotctrl/__init__.py
@@ -8,4 +8,4 @@ It could provide an RPC interface to a node in Python over the serial port
 and maybe also over network.
 """
 
-__version__ = '0.3.1'
+__version__ = '0.4.0'


### PR DESCRIPTION
As #19 got merged before I was able to bump the version for publication, here is said bump. #19 was an API amendment, so this justifies a minor version bump.