### PR TITLE
riotctrl.shell: flush pexpect before prompt

### DIFF
--- a/riotctrl/__init__.py
+++ b/riotctrl/__init__.py
@@ -8,4 +8,4 @@ It could provide an RPC interface to a node in Python over the serial port
 and maybe also over network.
 """
 
-__version__ = '0.4.0'
+__version__ = '0.4.1'


### PR DESCRIPTION
For some boards there is a weird syncing error happening: The output of a command issued via a ShellInteraction comes after the next command command issued. Examples of this can be seen in [this action](https://github.com/RIOT-OS/RIOT/runs/2004639066?check_suite_focus=true) or [in this comment](https://github.com/RIOT-OS/RIOT/pull/16111#issuecomment-788857286). With flushing pexpected completely before the prompt, this does not happen again. Thanks @fjmolinas for the hint!

For testing the tests here should pass, as well as `tests/congure_test` in RIOT on the boards we found the issue for; namely `nucleo-f411re`, `b-l072z-lrwan1`, and `b-l475e-iot01a`:

```console
$ git fetch upstream refs/pull/21/head # assuming you are in the riotctrl repo and RIOT-OS/riotctrl remote is called upstream
$ git checkout FETCH_HEAD
$ pip install .[rapidjson] --upgrade
$ cd ../RIOT     # assuming this is where your RIOT repo is
$ git checkout master
$ git pull
$ BOARD="<one of the above>" make -C tests/congure/test -f flash test
```