### PR TITLE
riotctrl.ctrl: add flash method for RIOTCtrl

### DIFF
--- a/riotctrl/ctrl.py
+++ b/riotctrl/ctrl.py
@@ -13,7 +13,7 @@ import contextlib
 import pexpect
 
 
-DEVNULL = open(os.devnull, 'w')
+DEVNULL = subprocess.DEVNULL
 MAKE = os.environ.get('MAKE', 'make')
 
 

--- a/riotctrl/ctrl.py
+++ b/riotctrl/ctrl.py
@@ -88,6 +88,7 @@ class RIOTCtrl():
     TERM_STARTED_DELAY = int(os.environ.get('RIOT_TERM_START_DELAY') or 3)
 
     MAKE_ARGS = ()
+    FLASH_TARGETS = ('flash',)
     RESET_TARGETS = ('reset',)
     TERM_TARGETS = ('cleanterm',)
 
@@ -109,6 +110,20 @@ class RIOTCtrl():
     def board(self):
         """Return board type."""
         return self.env['BOARD']
+
+    def flash(self, *runargs, stdout=DEVNULL, stderr=DEVNULL, **runkwargs):
+        """Flash application in ``ctrl.application_directory`` to ctrl.
+
+        :param stdout: stdout parameter passed to ctrl.make_run
+                       (default: DEVNULL)
+        :param stderr: stdout parameter passed to ctrl.make_run
+                       (default: DEVNULL)
+        :param *runargs: args passed to subprocess.run
+        :param *runkwargs: kwargs passed to subprocess.run
+        :return: subprocess.CompletedProcess object
+        """
+        self.make_run(self.FLASH_TARGETS, *runargs,
+                      stdout=stdout, stderr=stderr, **runkwargs)
 
     def reset(self):
         """Reset current ctrl."""

--- a/riotctrl/tests/ctrl_test.py
+++ b/riotctrl/tests/ctrl_test.py
@@ -224,12 +224,13 @@ def test_term_cleanup(app_pidfile_env):
         with ctrl.run_term(logfile=sys.stdout) as child:
             child.expect_exact('Running')
             # Ensure script is started correctly
-            content = open(tmpfile.name, 'r', encoding='utf-8').read()
-            assert content == 'Running\n'
+            with open(tmpfile.name, 'r', encoding='utf-8') as tempfile_r:
+                assert tempfile_r.read() == 'Running\n'
 
         # File should not exist anymore so no error to create one
         # File must exist to be cleaned by tempfile
-        open(tmpfile.name, 'x')
+        with open(tmpfile.name, 'x', encoding='utf-8'):
+            pass
 
 
 class CtrlMock1(riotctrl.ctrl.RIOTCtrl):

--- a/riotctrl/tests/ctrl_test.py
+++ b/riotctrl/tests/ctrl_test.py
@@ -52,6 +52,28 @@ def test_riotctrl_curdir():
         os.environ.update(_environ)
 
 
+def test_riotctrl_flash(monkeypatch):
+    """Test the flash method of a riotctrl."""
+    args = []
+    kwargs = []
+
+    def make_run_mock(self, *_args, **_kwargs):
+        """
+        Mocks RIOTCtrl's make_run method
+        """
+        # pylint: disable=unused-argument
+        args.append(_args)
+        kwargs.append(_kwargs)
+
+    monkeypatch.setattr(riotctrl.ctrl.RIOTCtrl, 'make_run', make_run_mock)
+    ctrl = riotctrl.ctrl.RIOTCtrl(APPLICATIONS_DIR)
+    ctrl.flash()
+    assert len(args) == len(kwargs) == 1
+    assert args[-1] == (riotctrl.ctrl.RIOTCtrl.FLASH_TARGETS,)
+    assert kwargs[-1] == {'stderr': riotctrl.ctrl.DEVNULL,
+                          'stdout': riotctrl.ctrl.DEVNULL}
+
+
 @pytest.fixture(name='app_pidfile_env')
 def fixture_app_pidfile_env():
     """Environment to use application pidfile"""


### PR DESCRIPTION
This adds a `flash` method for RIOTCtrl. The idea is, that with https://github.com/RIOT-OS/riotctrl/pull/13 an inherited class can easily override it, that e.g. with `iotlabcli` it only has to be called once for all nodes.