### PR TITLE
setup.cfg: ignore consider-using-f-string for now

### DIFF
--- a/riotctrl/__init__.py
+++ b/riotctrl/__init__.py
@@ -8,4 +8,4 @@ It could provide an RPC interface to a node in Python over the serial port
 and maybe also over network.
 """
 
-__version__ = '0.4.1'
+__version__ = '0.5.0'

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,6 +12,10 @@ lint-reports = no
 lint-disable = locally-disabled,star-args
 lint-msg-template = {path}:{line}: [{msg_id}({symbol}), {obj}] {msg}
 
+[pylint.messages control]
+disable=
+  consider-using-f-string   # should be removed when py3.5 support is dropped
+
 [flake8]
 exclude = .tox,dist,doc,build,*.egg
 max-complexity = 10


### PR DESCRIPTION
~~As with other places where we use `pylint` to lint our code: it is now complaining about the non-usage of f-strings. This fixes that (luckily this time it is small).~~ Told pylint to ignore the warning instead, as we still need python 3.5 support (see https://github.com/RIOT-OS/riotctrl/pull/24#issuecomment-923802382).

In addition, I added a version bump. It's about time for a new version: last one was in March, `riotctrl.flash()` was introduced since then and the README heavily amended (which will show up on pypi as the package description).