### PR TITLE
Add README.rst validation to the lint testenv

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -32,6 +32,9 @@ jobs:
       run: |
         pyenv="py$(echo "${{ matrix.python-version }}" | tr -d '.')"
         tox -e ${pyenv}-test,${pyenv}-rapidjson,flake8,lint
+    - name: Check package
+      if: matrix.python-version == 3.9
+      run: tox -e check_package
     - name: Publish package to PyPI
       uses: pypa/gh-action-pypi-publish@master
       if: >-

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
     version=get_version(PACKAGE),
     description='RIOT Ctrl - A RIOT node python abstraction',
     long_description=open('README.rst').read(),
+    long_description_content_type="text/x-rst",
     author='Gaëtan Harter, Leandro Lanzieri, Martine S. Lenders',
     author_email='gaetan.harter@fu-berlin.de, '
                  'leandro.lanzieri@haw-hamburg.de, '

--- a/tox.ini
+++ b/tox.ini
@@ -37,9 +37,11 @@ commands =
 deps =
     pylint
     pytest
+    twine
 commands =
     pylint --rcfile=setup.cfg {envsitepackagesdir}/{env:package}
     # This does not check files in 'tests/utils/application'
+    twine check --strict {distdir}/*
 
 [testenv:flake8]
 deps = flake8

--- a/tox.ini
+++ b/tox.ini
@@ -41,7 +41,7 @@ deps =
 commands =
     pylint --rcfile=setup.cfg {envsitepackagesdir}/{env:package}
     # This does not check files in 'tests/utils/application'
-    twine check --strict {distdir}/*
+    twine check {distdir}/*
 
 [testenv:flake8]
 deps = flake8

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py35,py36,py37,py38,py39}-{test,rapidjson},lint,flake8
+envlist = {py35,py36,py37,py38,py39}-{test,rapidjson},lint,flake8,check_package
 skip_missing_interpreters = true
 
 [testenv]
@@ -12,11 +12,13 @@ deps =
     rapidjson:  {[testenv:rapidjson]deps}
     lint:       {[testenv:lint]deps}
     flake8:     {[testenv:flake8]deps}
+    check_package:  {[testenv:check_package]deps}
 commands =
     test:       {[testenv:test]commands}
     rapidjson:  {[testenv:rapidjson]commands}
     lint:       {[testenv:lint]commands}
     flake8:     {[testenv:flake8]commands}
+    check_package:  {[testenv:check_package]commands}
 
 [testenv:test]
 deps =
@@ -37,10 +39,14 @@ commands =
 deps =
     pylint
     pytest
-    twine
 commands =
     pylint --rcfile=setup.cfg {envsitepackagesdir}/{env:package}
     # This does not check files in 'tests/utils/application'
+
+[testenv:check_package]
+deps =
+    twine
+commands =
     twine check {distdir}/*
 
 [testenv:flake8]

--- a/tox.ini
+++ b/tox.ini
@@ -47,7 +47,7 @@ commands =
 deps =
     twine
 commands =
-    twine check {distdir}/*
+    twine check --strict {distdir}/*
 
 [testenv:flake8]
 deps = flake8


### PR DESCRIPTION
As described [here](https://packaging.python.org/guides/making-a-pypi-friendly-readme/#validating-restructuredtext-markup), using twine it's possible to validate the rST Markup language of the README.

This PR adds a new command that does that to the Tox lint testenv.

This is based on #25 