### PR TITLE
riotctrl: bump version to v0.5.0

### DIFF
--- a/riotctrl/__init__.py
+++ b/riotctrl/__init__.py
@@ -8,4 +8,4 @@ It could provide an RPC interface to a node in Python over the serial port
 and maybe also over network.
 """
 
-__version__ = '0.4.1'
+__version__ = '0.5.0'


### PR DESCRIPTION
Sadly, even though the build failed, the v0.5.0 release [went somehow through to pypi](https://pypi.org/project/riotctrl/0.5.0/). So let's just keep it and fix the bug in the tests ASAP so we can progress to 0.5.1 (which we would need to do anyway, even if we delete the release on pypi. The commit is the same as it used to be in master, so please let's keep things simple and merge it as is.