### PR TITLE
black: don't skip string normalization

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -18,6 +18,3 @@ max-line-length = 88
 extend-ignore = E203
 exclude = .tox,dist,doc,build,*.egg
 max-complexity = 10
-
-[tool.black]
-skip-string-normalization = true


### PR DESCRIPTION
This PR removes the skip string normalization used with black (mostly replaces single quotes with double quotes). In #27, the blackification of the code was initially performed without this option and I think I added it to skip changes I had locally.

The CI should remain green.