### PR TITLE
ctrl: fix return of flash

### DIFF
--- a/riotctrl/ctrl.py
+++ b/riotctrl/ctrl.py
@@ -133,7 +133,7 @@ class RIOTCtrl:
         :param *runkwargs: kwargs passed to subprocess.run
         :return: subprocess.CompletedProcess object
         """
-        self.make_run(
+        return self.make_run(
             self.FLASH_TARGETS, *runargs, stdout=stdout, stderr=stderr, **runkwargs
         )
 


### PR DESCRIPTION
Although it's documented, the `flash` method does not return the result of the sub-process. This is useful to check whether the flashing worked.