### PR TITLE
ci: use available python versions

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -12,17 +12,17 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       max-parallel: 5
       fail-fast: false
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
+        python-version: ['3.8', '3.9', '3.12']
 
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -34,15 +34,15 @@ jobs:
         pyenv="py$(echo "${{ matrix.python-version }}" | tr -d '.')"
         tox -e ${pyenv}-test,${pyenv}-rapidjson,flake8,lint
     - name: Check code format with black
-      if: matrix.python-version == 3.9
+      if: matrix.python-version == '3.9'
       run: tox -e black
     - name: Check package
-      if: matrix.python-version == 3.9
+      if: matrix.python-version == '3.9'
       run: tox -e check_package
     - name: Publish package to PyPI
       uses: pypa/gh-action-pypi-publish@master
       if: >-
-        matrix.python-version == 3.9 &&
+        matrix.python-version == '3.9' &&
         github.event_name == 'push' &&
         startsWith(github.event.ref, 'refs/tags')
       with:

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -36,6 +36,9 @@ jobs:
     - name: Check code format with black
       if: matrix.python-version == '3.9'
       run: tox -e black
+    - name: Build package
+      if: matrix.python-version == '3.9'
+      run: tox -e build
     - name: Check package
       if: matrix.python-version == '3.9'
       run: tox -e check_package

--- a/riotctrl/ctrl.py
+++ b/riotctrl/ctrl.py
@@ -234,7 +234,6 @@ class RIOTCtrlFactoryBase(abc.ABC):
         :param env:                   `env` initialization parameter for
                                       the RIOTCtrl object.
         """
-        ...  # pragma: no cover
 
 
 class RIOTCtrlBoardFactory(RIOTCtrlFactoryBase):

--- a/riotctrl/tests/ctrl_test.py
+++ b/riotctrl/tests/ctrl_test.py
@@ -19,9 +19,6 @@ def test_not_implemented_factory():
     class MyFactory(riotctrl.ctrl.RIOTCtrlFactoryBase):
         """Dummy factory class that cannot be instanciated."""
 
-        # pylint:disable=too-few-public-methods
-        ...
-
     with pytest.raises(TypeError) as exc_info:
         _ = MyFactory()  # pylint:disable=abstract-class-instantiated
 

--- a/riotctrl/tests/riotctrl_test.py
+++ b/riotctrl/tests/riotctrl_test.py
@@ -1,4 +1,5 @@
 """riotctrl.__init__ tests"""
+
 import riotctrl
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,7 @@ markers =
 [pylint]
 reports = no
 max-line-length = 88
-disable = locally-disabled,star-args,consider-using-f-string
+disable = locally-disabled,consider-using-f-string,invalid-name,too-few-public-methods
 msg-template = {path}:{line}: [{msg_id}({symbol}), {obj}] {msg}
 
 [flake8]

--- a/tox.ini
+++ b/tox.ini
@@ -45,11 +45,31 @@ commands =
     pylint --rcfile=setup.cfg {envsitepackagesdir}/{env:package}
     # This does not check files in 'tests/utils/application'
 
+[testenv:{build,clean}]
+description =
+    build: Build the package in isolation according to PEP517, see https://github.com/pypa/build
+    clean: Remove old distribution files and temporary build artifacts (./build and ./dist)
+# https://setuptools.pypa.io/en/stable/build_meta.html#how-to-use-it
+skip_install = True
+changedir = {toxinidir}
+deps =
+    build: build[virtualenv]
+passenv =
+    SETUPTOOLS_*
+commands =
+    clean: python -c 'import shutil; [shutil.rmtree(p, True) for p in ("build", "dist", "docs/_build")]'
+    clean: python -c 'import pathlib, shutil; [shutil.rmtree(p, True) for p in pathlib.Path("src").glob("*.egg-info")]'
+    build: python -m build {posargs}
+# By default, both `sdist` and `wheel` are built. If your sdist is too big or you don't want
+# to make it available, consider running: `tox -e build -- --wheel`
+
 [testenv:check_package]
+changedir = {toxinidir}
+skip_install = True
 deps =
     twine
 commands =
-    twine check --strict {distdir}/*
+    python -m twine check dist/*
 
 [testenv:flake8]
 deps = flake8


### PR DESCRIPTION
The build of #33 shows problems with the python versions used for testing. According to the error message, the available ones are listed [here](https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json). This updates the CI file to use the newest patch versions of all the tested versions.