### PR TITLE
ctrl: set term to `None` when stopped

### DIFF
--- a/riotctrl/ctrl.py
+++ b/riotctrl/ctrl.py
@@ -190,6 +190,8 @@ class RIOTCtrl:
             # Not sure how to cover this in a test
             # 'make term' is not killed by 'term.close()'
             self.logger.critical("Could not close make term")
+        finally:
+            self.term = None
 
     def make_run(self, targets, *runargs, **runkwargs):
         """Call make `targets` for current RIOTctrl context.


### PR DESCRIPTION
When `stop_term` is called, `term` is not set to `None`. This breaks the check of `check_term`, as it tries to continue on using the file descriptor which is no longer valid.