### PR TITLE
shell: reset term flag when stopping term

### DIFF
--- a/riotctrl/shell/__init__.py
+++ b/riotctrl/shell/__init__.py
@@ -74,6 +74,7 @@ class ShellInteraction:
         """
         Stops the terminal of the RIOTCtrl object
         """
+        self.term_was_started = False
         self.riotctrl.stop_term()
 
     @staticmethod


### PR DESCRIPTION
As the title indicates: we should reset the flag when manually stopping the terminal.