### PR TITLE
ctrl: send termination signals to the process group

### DIFF
--- a/riotctrl/ctrl.py
+++ b/riotctrl/ctrl.py
@@ -6,6 +6,7 @@ Define class to abstract a node over the RIOT build system.
 import abc
 import os
 import time
+import signal
 import logging
 import subprocess
 import contextlib
@@ -179,7 +180,14 @@ class RIOTCtrl:
 
         Handles possible exceptions.
         """
+        if self._term_pid() is None:
+            return
+
         try:
+            # Native will spawn more than one process, so send the signals
+            # to the process group instead of the process.
+            os.killpg(self._term_pid(), signal.SIGHUP)
+            os.killpg(self._term_pid(), signal.SIGINT)
             self.term.close()
         except AttributeError:
             # Not initialized

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,6 +10,7 @@ markers =
 [pylint]
 reports = no
 max-line-length = 88
+max-positional-arguments = 6
 disable = locally-disabled,consider-using-f-string,invalid-name,too-few-public-methods
 msg-template = {path}:{line}: [{msg_id}({symbol}), {obj}] {msg}
 


### PR DESCRIPTION
The native platform on RIOT spawns two processes instead of one, so that sending the termination signal to just one process might leave a stray process open. This causes a PTY leak and eventually breaks the CI servers.

With the current `master`:
```
cbuec@W11nMate:~/RIOTstuff/riot-vanilla/RIOT$ make -C tests/turo all test && ps -A | grep -i turo
make: Entering directory '/home/cbuec/RIOTstuff/riot-vanilla/RIOT/tests/turo'
using BOARD="native64" as "native" on a 64-bit system
Building application "tests_turo" for "native64" with CPU "native".

"make" -C /home/cbuec/RIOTstuff/riot-vanilla/RIOT/boards
...
"make" -C /home/cbuec/RIOTstuff/riot-vanilla/RIOT/sys/tsrb
   text    data     bss     dec     hex filename
  40572    1368   59200  101140   18b14 /home/cbuec/RIOTstuff/riot-vanilla/RIOT/tests/turo/bin/native64/tests_turo.elf
.............
----------------------------------------------------------------------
Ran 13 tests in 4.996s

OK
make: Leaving directory '/home/cbuec/RIOTstuff/riot-vanilla/RIOT/tests/turo'
  12327 ?        00:00:00 tests_turo.elf
```

With this PR:
```
cbuec@W11nMate:~/RIOTstuff/riot-vanilla/RIOT$ make -C tests/turo all test && ps -A | grep -i turo
make: Entering directory '/home/cbuec/RIOTstuff/riot-vanilla/RIOT/tests/turo'
using BOARD="native64" as "native" on a 64-bit system
Building application "tests_turo" for "native64" with CPU "native".

"make" -C /home/cbuec/RIOTstuff/riot-vanilla/RIOT/boards
...
"make" -C /home/cbuec/RIOTstuff/riot-vanilla/RIOT/sys/tsrb
   text    data     bss     dec     hex filename
  40572    1368   59200  101140   18b14 /home/cbuec/RIOTstuff/riot-vanilla/RIOT/tests/turo/bin/native64/tests_turo.elf
.............
----------------------------------------------------------------------
Ran 13 tests in 4.471s

OK
make: Leaving directory '/home/cbuec/RIOTstuff/riot-vanilla/RIOT/tests/turo'
```