### PR TITLE
riotctrl: bump version to 0.5.1

### DIFF
--- a/riotctrl/__init__.py
+++ b/riotctrl/__init__.py
@@ -8,4 +8,4 @@ It could provide an RPC interface to a node in Python over the serial port
 and maybe also over network.
 """
 
-__version__ = "0.5.0"
+__version__ = "0.5.1"


### PR DESCRIPTION
After the merge of #37, the version has to be increased before the release.