### PR TITLE
workflows: change to release/v1 from unsupported master

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -43,7 +43,7 @@ jobs:
       if: matrix.python-version == '3.9'
       run: tox -e check_package
     - name: Publish package to PyPI
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@release/v1
       if: >-
         matrix.python-version == '3.9' &&
         github.event_name == 'push' &&


### PR DESCRIPTION
The `master` branch has been sunset and this might be the cause of the build failing:
https://github.com/pypa/gh-action-pypi-publish/tree/release/v1?tab=readme-ov-file#-master-branch-sunset-

![Screenshot 2025-04-26 163020](https://github.com/user-attachments/assets/03313610-bec2-4296-889b-3fdfc2acb9aa)
![image](https://github.com/user-attachments/assets/7bbd4df3-652b-4337-aff0-7d27b289a3d9)
