### PR TITLE
workflows,tox: add more python versions, fix `too-many-positional-arguments` warning for all versions

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Test with tox
       run: |
         pyenv="py$(echo "${{ matrix.python-version }}" | tr -d '.')"
-        tox -e ${pyenv}-test,${pyenv}-rapidjson,flake8,lint
+        tox -e ${pyenv}-test,${pyenv}-rapidjson,flake8,${pyenv}-lint
     - name: Check code format with black
       if: matrix.python-version == '3.9'
       run: tox -e black

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,6 @@ markers =
 [pylint]
 reports = no
 max-line-length = 88
-max-positional-arguments = 6
 disable = locally-disabled,consider-using-f-string,invalid-name,too-few-public-methods
 msg-template = {path}:{line}: [{msg_id}({symbol}), {obj}] {msg}
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py35,py36,py37,py38,py39}-{test,rapidjson},lint,flake8,check_package,black
+envlist = {py35,py36,py37,py38,py39,py310,py311,py312}-{test,rapidjson},lint,flake8,check_package,black
 skip_missing_interpreters = true
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py35,py36,py37,py38,py39,py310,py311,py312}-{test,rapidjson},lint,flake8,check_package,black
+envlist = py3{5,6,7,8,9,10,11,12}-{test,rapidjson,lint},flake8,check_package,black
 skip_missing_interpreters = true
 
 [testenv]
@@ -37,12 +37,22 @@ deps =
 commands =
     pytest -m "rapidjson" {posargs}
 
-[testenv:lint]
+[testenv:py3{5,6,7,8}-lint]
 deps =
     pylint
     pytest
 commands =
     pylint --rcfile=setup.cfg {envsitepackagesdir}/{env:package}
+    # This does not check files in 'tests/utils/applications'    
+
+[testenv:py3{9,10,11,12}-lint]
+deps =
+    pylint
+    pytest
+commands =
+    # older pylint versions are incompatible with `too-many-positional-arguments`,
+    # therefore it can not be added to the setup.cfg
+    pylint --disable=too-many-positional-arguments --rcfile=setup.cfg {envsitepackagesdir}/{env:package}
     # This does not check files in 'tests/utils/application'
 
 [testenv:{build,clean}]


### PR DESCRIPTION
Unfortunately the fix introduced in https://github.com/RIOT-OS/riotctrl/commit/5e679ed3446c492eead15ecd1179b0061b41c9a3 caused an issue with the earlier pylint versions that somehow did not get caught by the workflow.

Therefore, this PR introduces a more stable fix that adds a condition for newer and older python versions.

Also I added more Python versions to the `tox.ini` file to cover version 3.12 that is tested in the Workflows as well (and I have 3.10 locally, which was not covered either).