### PR TITLE
workflows: change to release/v1 from unsupported master

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -43,7 +43,7 @@ jobs:
       if: matrix.python-version == '3.9'
       run: tox -e check_package
     - name: Publish package to PyPI
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@release/v1
       if: >-
         matrix.python-version == '3.9' &&
         github.event_name == 'push' &&


### PR DESCRIPTION
The original PR #39 got broken somehow, GitHub seems to be stuck here:
![image](https://github.com/user-attachments/assets/c7077114-540a-4bfd-b081-9d237bd927dc)
