### PR TITLE
workflows: fix package directory

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -51,4 +51,4 @@ jobs:
       with:
         user: __token__
         password: ${{ secrets.PYPI_TOKEN }}
-        packages_dir: .tox/dist/
+        packages-dir: dist/


### PR DESCRIPTION
The suspected issue from #41 was not the cause for the PyPi failure. Instead, the output directory got changed in https://github.com/RIOT-OS/riotctrl/pull/34/commits/2e698dee414e7b3f4ebc6e488d49f62c62191d21#diff-ef2cef9f88b4fe09ca3082140e67f5ad34fb65fb6e228f119d3812261ae51449R54, which changed the path of the `dist` folder as well. The workflow was not changed, therefore the directory could not be found.

This also fixes a warning about the deprecated `packages_dir` variable.